### PR TITLE
get all potential methods

### DIFF
--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
@@ -13,13 +13,11 @@ object Utility {
     def getAllMethods(clz: Class[_]): Stream[Method] = {
         var curClz = clz;
         val methods = new ListBuffer[Method]()
-        val nameSet = HashSet[String]()
         while (curClz != null) {
             for (m <- curClz.getDeclaredMethods) {
-                if (!nameSet.contains(m.getName)) {
+                if (!methods.contains(m) && !m.isBridge()) {
                     // exclude override method
                     methods.append(m)
-                    nameSet.add(m.getName)
                 }
             }
             curClz = curClz.getSuperclass


### PR DESCRIPTION
Get all potential method objects to avoid name conflicts, and exclude bridge methods.