### PR TITLE
Collect public methods to avoid name conflicts

### DIFF
--- a/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
+++ b/testrunner-running/src/main/scala/edu/illinois/cs/testrunner/util/Utility.scala
@@ -1,6 +1,7 @@
 package edu.illinois.cs.testrunner.util
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneId}
 import scala.collection.mutable.HashSet
@@ -16,7 +17,7 @@ object Utility {
         val nameSet = HashSet[String]()
         while (curClz != null) {
             for (m <- curClz.getDeclaredMethods) {
-                if (!nameSet.contains(m.getName)) {
+                if (!nameSet.contains(m.getName) && Modifier.isPublic(m.getModifiers())) {
                     // exclude override method
                     methods.append(m)
                     nameSet.add(m.getName)


### PR DESCRIPTION
Collect `public` methods for collecting tests, to avoid name conflicts.